### PR TITLE
Adicionando IDE para Android - Quoda

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -100,7 +100,7 @@ internet após o download inicial dos aplicativos.
   
 ### Quoda
 - Download:
-  - Google Play: **<hthttps://play.google.com/store/apps/details?id=com.henrythompson.quoda>**
+  - Google Play: **<https://play.google.com/store/apps/details?id=com.henrythompson.quoda>**
   - Tamanho: **8,5MB** (verificado em 2020-11-21)
 - Requisito mínimos:
   - Versão do Android: **4.0.3+**

--- a/android/README.md
+++ b/android/README.md
@@ -97,6 +97,13 @@ internet após o download inicial dos aplicativos.
   - Acesso à internet: **requer conexão ativa** (não funciona offline)
 - Links do desenvolvedor:
   - Site Oficial: <https://dcoder.tech/> <sup>destino em inglês</sup>
+  
+### Quoda
+- Download:
+  - Google Play: **<hthttps://play.google.com/store/apps/details?id=com.henrythompson.quoda>**
+  - Tamanho: **8,5MB** (verificado em 2020-11-21)
+- Requisito mínimos:
+  - Versão do Android: **4.0.3+**
 
 ## Terminal para Android
 


### PR DESCRIPTION
Conforme discussão em **Android/Editor-de-Código: Dcoder #40** este Pull request propõe:

```
### Quoda
- Download:
  - Google Play: **<https://play.google.com/store/apps/details?id=com.henrythompson.quoda>**
  - Tamanho: **8,5MB** (verificado em 2020-11-21)
- Requisito mínimos:
  - Versão do Android: **4.0.3+**
```